### PR TITLE
Address a couple of CVE's (bump versions). 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,27 +8,37 @@
     <artifactId>shift-rest</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
+    <parent>
+	  <groupId>org.springframework.boot</groupId>
+	  <artifactId>spring-boot-starter-parent</artifactId>
+	  <version>2.1.5.RELEASE</version>
+	  <relativePath />
+    </parent>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot.bom.version>2.1.2.Final-redhat-00003</spring-boot.bom.version>
-        <springboot.version>2.1.2.RELEASE</springboot.version>
+        <spring-boot.bom.version>2.1.5.RELEASE</spring-boot.bom.version>
+        <springboot.version>2.1.5.RELEASE</springboot.version>
         <springfox-version>2.8.0</springfox-version>
         <swagger-core-version>1.5.10</swagger-core-version>
+
+
+		<spring-cloud.version>Finchley.SR1</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>spring-boot-bom</artifactId>
-                <version>${spring-boot.bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -55,6 +65,33 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Addresses CVE-2019-12086 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+
+        <!-- There's a bunch of CVE's associated with this version 
+             unfortunately, they're not all fixed yet, so we've added a
+             suppression for now in project-suppression.xml until the end
+             of the year against CVE-2018-1067 -->
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>2.0.22.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>2.0.22.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+            <version>2.0.22.Final</version>
         </dependency>
         <!--SpringFox dependencies -->
         <!--
@@ -136,7 +173,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.0.0-M1</version>
+                <version>5.0.0</version>
                 <configuration>
                     <failBuildOnCVSS>4</failBuildOnCVSS>
                     <suppressionFile>project-suppression.xml</suppressionFile>
@@ -152,7 +189,7 @@
         </plugins>
     </build>
 
-    <repositories>
+    <!--<repositories>
         <repository>
             <id>redhat-ga-repository</id>
             <name>Redhat GA Repository</name>
@@ -165,5 +202,5 @@
             <name>Redhat GA Repository</name>
             <url>https://maven.repository.redhat.com/ga/all/</url>
         </pluginRepository>
-    </pluginRepositories>
+    </pluginRepositories>-->
 </project>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -12,4 +12,10 @@
 	   ]]></notes>
         <cpe>cpe:/a:springsource:spring_framework:1.2.0</cpe>
     </suppress>
+    <suppress until="2020-01-01Z">
+        <notes><![CDATA[
+        This suppresses a specific cve for any dependency in any directory that has the specified sha1 checksum. If current date is not yet on or beyond 1 Jan 2020.
+        ]]></notes>
+        <cve>CVE-2018-1067</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Updated suppressions to ignore (for now) CVS-2018-1067 in undertow.

Switched to spring-boot-starter-parent 2.1.5.RELEASE for easier builds.